### PR TITLE
Debug GitHub Action Pull Request Test Failure

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,7 +51,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha,prefix={{branch}}-
+            type=sha
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push Docker image


### PR DESCRIPTION
The workflow was failing with "invalid tag" error because the SHA tag was using `prefix={{branch}}-` which resulted in tags like `-decd393` when the branch placeholder was empty or not populated correctly during pull request builds.

Changed from `type=sha,prefix={{branch}}-` to `type=sha` to generate valid SHA-based tags without the problematic prefix.

Fixes the Docker build error:
ERROR: invalid tag "ghcr.io/ndsrf/wine-tasting-game:-decd393"

🤖 Generated with [Claude Code](https://claude.com/claude-code)